### PR TITLE
pin gdal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,9 @@ osx_image: xcode6.4
 env:
   matrix:
     
-    - CONDA_NPY=111  CONDA_PY=27
-    - CONDA_NPY=112  CONDA_PY=27
-    - CONDA_NPY=113  CONDA_PY=27
-    - CONDA_NPY=111  CONDA_PY=35
-    - CONDA_NPY=112  CONDA_PY=35
-    - CONDA_NPY=113  CONDA_PY=35
-    - CONDA_NPY=111  CONDA_PY=36
-    - CONDA_NPY=112  CONDA_PY=36
-    - CONDA_NPY=113  CONDA_PY=36
+    - CONDA_PY=27
+    - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "lFRTnKG8pyOr+x4DqRjjJhXzk5oIIAxugNHcdWGmt1/h4isDReRQn4zPscaTiGkv6UERamBvwMf2b3+iBf/e/T+ghSY122GCG1sK4xYKYiLupaB8CSR2EJEwPDLO7yi2jehE8k6g+A4m8eQQ2bzO78cu5bWVdSLIOhfSka2OUIVzorshLBiMgFz3Yr/HynYJ5aiqyL3Tq2jI51fTrsdDR0XyUHHxw2XoT223gXEj54HyIIHDYE+fOTVddUqlunD9UURcTkXvrFJ3wjOivj+wK5CJ2AL/pFCVrjD0g6zf9VqyIQEWvw5KIAB/1zZX+eT+s9CoexOcdxC/Ehwpfejp/yZdxqea1UV7dD+f5C0JrIR7f6b5X/PPEsULB4AbptYHwfMbtelPjOvX+iM8GYGLd/VzMwNrz66BtCkOa3SHxwkj14w2nvyzWgGdJehgNsA1q/JNXikHMQwEyQ+8kA6X69EVNp9VQ6pVOFei+cLJj5OiyyOLGvZVSWg9LFfS5s8rC/5wsXEOPUrVj5nruz2V12kY4Q8YYosZJseE9BfwjO9OtWy6VLzF8FnaJoAzaPVNlbSOF8jksV2FP4P6wPMDRWbbkN5or/D15/FWBwYb7MWKROB1IvHVochSovdkPlS38DePtI2Qe8XJedEM725rlGBbk0RNRiebjmiMo3eAVrk="

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About tuiview
 
 Home: http://tuiview.org/
 
-Package license: GPLv2
+Package license: GPL-2.0
 
 Feedstock license: BSD 3-Clause
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,92 +10,26 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
-      CONDA_NPY: 111
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
       CONDA_PY: 27
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
-      CONDA_NPY: 112
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 112
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 113
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 113
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 111
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
     - TARGET_ARCH: x86
-      CONDA_NPY: 112
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 112
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 113
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 113
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 111
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 112
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 112
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
-
-    - TARGET_ARCH: x86
-      CONDA_NPY: 113
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36
-
-    - TARGET_ARCH: x64
-      CONDA_NPY: 113
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -57,65 +57,20 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 9 case(s).
+# Embarking on 3 case(s).
     set -x
-    export CONDA_NPY=111
     export CONDA_PY=27
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=112
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=113
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=111
     export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_NPY=112
-    export CONDA_PY=35
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=113
-    export CONDA_PY=35
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=111
-    export CONDA_PY=36
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=112
-    export CONDA_PY=36
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_NPY=113
     export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,14 +21,14 @@ requirements:
     - numpy 1.7.*  # [py27]
     - numpy 1.9.*  # [py35]
     - numpy 1.11.*  # [py36]
-    - gdal
+    - gdal 2.1.*
     - pyqt 5.6.*
   run:
     - python
     - numpy >=1.7  # [py27]
     - numpy >=1.9  # [py35]
     - numpy >=1.11  # [py36]
-    - gdal
+    - gdal 2.1.*
     - pyqt 5.6.*
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,43 +1,52 @@
 {% set version = "1.2.0" %}
 
-
 package:
-    name: tuiview
-    version: {{ version }}
+  name: tuiview
+  version: {{ version }}
 
 source:
-    fn: TuiView-{{ version }}.tar.gz
-    url: https://bitbucket.org/chchrsc/tuiview/downloads/TuiView-{{ version }}.tar.gz
-    sha256: 1340136787f29b1f9146cf4819f7d44fffc8887707c42e78c79b7c7c9f6ba4e2
+  fn: TuiView-{{ version }}.tar.gz
+  url: https://bitbucket.org/chchrsc/tuiview/downloads/TuiView-{{ version }}.tar.gz
+  sha256: 1340136787f29b1f9146cf4819f7d44fffc8887707c42e78c79b7c7c9f6ba4e2
 
 build:
-    number: 0
-    entry_points:
-        - tuiview = tuiview.viewerapplication:run
-        - tuiviewwritetable = tuiview.writetableapplication:run
+  number: 0
+  entry_points:
+    - tuiview = tuiview.viewerapplication:run
+    - tuiviewwritetable = tuiview.writetableapplication:run
 
 requirements:
-    build:
-        - python
-        - numpy x.x
-        - gdal 2.2.*
-        - pyqt 5.6.*
-    run:
-        - python
-        - numpy x.x
-        - gdal 2.2.*
-        - pyqt 5.6.*
+  build:
+    - python
+    - numpy 1.7.*  # [py27]
+    - numpy 1.9.*  # [py35]
+    - numpy 1.11.*  # [py36]
+    - gdal
+    - pyqt 5.6.*
+  run:
+    - python
+    - numpy >=1.7  # [py27]
+    - numpy >=1.9  # [py35]
+    - numpy >=1.11  # [py36]
+    - gdal
+    - pyqt 5.6.*
 
 test:
-    imports:
-        - tuiview
+  imports:
+    - tuiview
+  commands:
+    - tuiviewwritetable -h
+    - conda inspect linkages -p $PREFIX tuiview  # [not win]
+    - conda inspect objects -p $PREFIX tuiview  # [osx]
 
 about:
-    home: http://tuiview.org/
-    license: GPLv2
-    summary: Simple raster viewer. Supports Geolinked Windows, Raster Attribute Querying and Editing and Geographic Selection, Vector Overlay, Flicker, Profile Tool. 
+  home: http://tuiview.org/
+  license: GPL-2.0
+  # Not present in the tarball.
+  # license_file: LICENSE.txt
+  summary: Simple raster viewer. Supports Geolinked Windows, Raster Attribute Querying and Editing and Geographic Selection, Vector Overlay, Flicker, Profile Tool.
 
 extra:
-    recipe-maintainers:
-        - gillins
-        - danclewley
+  recipe-maintainers:
+    - gillins
+    - danclewley


### PR DESCRIPTION
Not sure we can unpin `gdal` here b/c it is linking to it. Here is the results of `conda-inspect`:

```
+ conda inspect linkages -p /opt/conda/conda-bld/tuiview_1500901336287/_t_env tuiview
tuiview
-------

curl-7.54.1-0:
    libcurl.so.4 (lib/libcurl.so.4)

expat-2.2.1-0:
    libexpat.so.1 (lib/libexpat.so.1)

freexl-1.0.2-2:
    libfreexl.so.1 (lib/libfreexl.so.1)

geos-3.5.1-1:
    libgeos-3.5.1.so (lib/libgeos-3.5.1.so)
    libgeos_c.so.1 (lib/libgeos_c.so.1)

giflib-5.1.4-0:
    libgif.so.7 (lib/libgif.so.7)

hdf4-4.2.12-0:
    libdf.so.0 (lib/libdf.so.0)
    libmfhdf.so.0 (lib/libmfhdf.so.0)

hdf5-1.8.18-0:
    libhdf5.so.10 (lib/libhdf5.so.10)
    libhdf5_cpp.so.13 (lib/libhdf5_cpp.so.13)
    libhdf5_hl.so.10 (lib/libhdf5_hl.so.10)

icu-58.1-1:
    libicudata.so.58 (lib/libicudata.so.58)
    libicui18n.so.58 (lib/libicui18n.so.58)
    libicuuc.so.58 (lib/libicuuc.so.58)

jpeg-9b-0:
    libjpeg.so.9 (lib/libjpeg.so.9)

json-c-0.12.1-0:
    libjson-c.so.2 (lib/libjson-c.so.2)

kealib-1.4.7-2:
    libkea.so.1.4.7 (lib/libkea.so.1.4.7)

krb5-1.14.2-0:
    libcom_err.so.3 (lib/libcom_err.so.3)
    libgssapi_krb5.so.2 (lib/libgssapi_krb5.so.2)
    libk5crypto.so.3 (lib/libk5crypto.so.3)
    libkrb5.so.3 (lib/libkrb5.so.3)
    libkrb5support.so.0 (lib/libkrb5support.so.0)

libdap4-3.18.3-2:
    libdap.so.23 (lib/libdap.so.23)
    libdapclient.so.6 (lib/libdapclient.so.6)
    libdapserver.so.7 (lib/libdapserver.so.7)

libgdal-2.2.1-0:
    libgdal.so.20 (lib/libgdal.so.20)

libiconv-1.14-4:
    libcharset.so.1 (lib/libcharset.so.1)
    libiconv.so.2 (lib/libiconv.so.2)

libnetcdf-4.4.1.1-5:
    libnetcdf.so.11 (lib/libnetcdf.so.11)

libpng-1.6.28-0:
    libpng16.so.16 (lib/libpng16.so.16)

libpq-9.5.4-4:
    libpq.so.5 (lib/libpq.so.5)

libspatialite-4.3.0a-15:
    libspatialite.so.7 (lib/libspatialite.so.7)

libssh2-1.8.0-1:
    libssh2.so.1 (lib/libssh2.so.1)

libtiff-4.0.6-7:
    libtiff.so.5 (lib/libtiff.so.5)

libxml2-2.9.4-4:
    libxml2.so.2 (lib/libxml2.so.2)

openjpeg-2.1.2-3:
    libopenjp2.so.7 (lib/libopenjp2.so.7)

openssl-1.0.2l-0:
    libcrypto.so.1.0.0 (lib/libcrypto.so.1.0.0)
    libssl.so.1.0.0 (lib/libssl.so.1.0.0)

proj4-4.9.3-4:
    libproj.so.12 (lib/libproj.so.12)

python-3.6.2-0:
    libpython3.6m.so.1.0 (lib/libpython3.6m.so.1.0)

sqlite-3.13.0-1:
    libsqlite3.so.0 (lib/libsqlite3.so.0)

util-linux-2.21-0:
    libuuid.so.1 (lib/libuuid.so.1)

xerces-c-3.1.4-3:
    libxerces-c-3.1.so (lib/libxerces-c-3.1.so)

xz-5.2.2-0:
    liblzma.so.5 (lib/liblzma.so.5)

zlib-1.2.11-0:
    libz.so.1 (lib/libz.so.1)

system:
    libc.so.6 (/lib64/libc.so.6)
    libdl.so.2 (/lib64/libdl.so.2)
    libgcc_s.so.1 (/lib64/libgcc_s.so.1)
    libm.so.6 (/lib64/libm.so.6)
    libpthread.so.0 (/lib64/libpthread.so.0)
    libresolv.so.2 (/lib64/libresolv.so.2)
    librt.so.1 (/lib64/librt.so.1)
    libstdc++.so.6 (/usr/lib64/libstdc++.so.6)
    libutil.so.1 (/lib64/libutil.so.1)
    linux-vdso.so.1 ()
```